### PR TITLE
Support binding to multiple ports

### DIFF
--- a/cmd/acp/config.go
+++ b/cmd/acp/config.go
@@ -23,11 +23,15 @@ type Config struct {
 	PSK     string `json:"psk"`
 	Server  string `json:"server,omitempty"`
 	UseIPv6 bool   `json:"ipv6,omitempty"`
+	Ports   []int  `json:"ports,omitempty"`
 }
 
 func (conf *Config) applyDefault() {
 	if conf.Server == "" {
 		conf.Server = "https://acp.deno.dev"
+	}
+	if len(conf.Ports) == 0 {
+		conf.Ports = []int{0}
 	}
 }
 

--- a/cmd/acp/config_test.go
+++ b/cmd/acp/config_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -31,6 +32,7 @@ func TestSetupWith(t *testing.T) {
 		PSK:     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 		Server:  "http://localhost:8000",
 		UseIPv6: true,
+		Ports:   []int{0, 9527},
 	}
 	conf0Bytes, _ := json.Marshal(&conf0)
 	if err := setup(string(conf0Bytes)); err != nil {
@@ -40,7 +42,7 @@ func TestSetupWith(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get config: %v", err)
 	}
-	if *conf != conf0 {
+	if !reflect.DeepEqual(*conf, conf0) {
 		t.Fatalf("Config does not match the intented setup value: expect: %+v, got: %+v", conf0, conf)
 	}
 

--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -65,7 +65,7 @@ func main() {
 func transfer(ctx context.Context, conf *Config, filenames []string, loggerModel tea.Model) {
 	defer logger.End()
 
-	conn, err := pnet.HolePunching(ctx, conf.Server+"/exchange", conf.ID, conf.UseIPv6, logger)
+	conn, err := pnet.HolePunching(ctx, conf.Server+"/v2/exchange", conf.ID, conf.UseIPv6, logger)
 	if errors.Is(err, context.Canceled) || !checkErr(err) {
 		return
 	}

--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -65,7 +65,17 @@ func main() {
 func transfer(ctx context.Context, conf *Config, filenames []string, loggerModel tea.Model) {
 	defer logger.End()
 
-	conn, err := pnet.HolePunching(ctx, conf.Server+"/v2/exchange", conf.ID, conf.UseIPv6, logger)
+	conn, err := pnet.HolePunching(
+		ctx,
+		conf.Server+"/v2/exchange",
+		conf.ID,
+		len(filenames) > 0,
+		pnet.HolePunchingOptions{
+			UseIPv6: conf.UseIPv6,
+			Ports:   conf.Ports,
+		},
+		logger,
+	)
 	if errors.Is(err, context.Canceled) || !checkErr(err) {
 		return
 	}

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,7 +2,6 @@
 ## Advanced options
 
 `acp` stores config at `$HOME/.config/acp/config.json` (`%APPDATA%\acp\config.json` for Windows).
-In general, you need to make sure that all devices use the same config.
 After changing config on one device, run `acp --setup` to get the command for updating configs on other devices.
 
 List of configurable options:
@@ -10,6 +9,14 @@ List of configurable options:
 - `server` (default: `"https://acp.deno.dev"`): Endpoint for coordinating rendezvous
 - `ipv6` (default: `false`): Establish P2P connection using IPv6 instead of IPv4.
   Note that both ends of a connection need to use the same IP protocol.
+- `ports` (default: `[0]`): Local port(s) binding for connection rendezvous.
+  This is useful if the device is in a network that configured to allow inbound connections only from specific ports.
+  e.g.
+	- `[0]`: bind to a random port;
+	- `[9527]`: bind to port 9527;
+	- `[0,9527]`: bind to a random port and port 9527.
+
+Make sure that all devices share the same config for entries `server` and `ipv6`.
 
 
 ## Host the rendezvous service yourself

--- a/edge/index.ts
+++ b/edge/index.ts
@@ -1,8 +1,37 @@
-import { serve } from "https://deno.land/std@0.171.0/http/server.ts";
+import { serve, type ConnInfo } from "https://deno.land/std@0.171.0/http/server.ts";
+
+
+interface ClientInfo {
+  priAddr: string,
+  chanName: string,
+}
+
+async function handleExchangeV2(req: Request, connInfo: ConnInfo): Promise<Response> {
+  if (req.method != "POST")
+    return new Response("Invalid method", { status: 405 })
+  if (req.headers.get("Content-Type") != "application/octet-stream")
+    return new Response("Invalid content type", { status: 415 })
+
+  const pubAddr = joinHostPort(connInfo.remoteAddr)
+  const conn = req.body!.getReader({ mode: "byob" })
+  const { priAddr, chanName }: ClientInfo = JSON.parse(
+    new TextDecoder().decode(await receivePacket(conn))
+  )
+  const x0 = JSON.stringify({ pubAddr, priAddr })
+  //console.log(`accepted from ${x0}`)
+
+  const x1 = await exchange(chanName, x0, conn)
+  if (x1 == "")
+    return new Response("")
+  //console.log(`exchanged, got ${x1}`)
+
+  const msg = marshallPacket(new TextEncoder().encode(x1))
+  return new Response(msg)
+}
 
 
 // (priAddr0|chanName) -> pubAddr1|priAddr1
-async function handleExchange(req: Request, connInfo: ConnInfo): Promise<Response> {
+async function handleExchangeV1(req: Request, connInfo: ConnInfo): Promise<Response> {
   if (req.method != "POST")
     return new Response("Invalid method", { status: 405 })
   if (req.headers.get("Content-Type") != "application/octet-stream")
@@ -117,8 +146,10 @@ async function handler(req: Request, connInfo: ConnInfo): Promise<Response> {
         `,
         { headers: { "Content-Type": "text/plain; charset=utf-8" } }
       )
+    case "/v2/exchange":
+      return await handleExchangeV2(req, connInfo)
     case "/exchange":
-      return await handleExchange(req, connInfo)
+      return await handleExchangeV1(req, connInfo)
     default:
       return new Response("Not found", { status: 404 })
   }

--- a/pkg/pnet/httpclient.go
+++ b/pkg/pnet/httpclient.go
@@ -11,7 +11,7 @@ type HTTPClient struct {
 	chLaddr chan net.Addr
 }
 
-func NewHTTPClient(useIpv6 bool) *HTTPClient {
+func NewHTTPClient(useIpv6 bool, laddr string) *HTTPClient {
 	client := &HTTPClient{
 		Client:  &http.Client{},
 		chLaddr: make(chan net.Addr, 1),
@@ -23,7 +23,7 @@ func NewHTTPClient(useIpv6 bool) *HTTPClient {
 		if useIpv6 {
 			network = "tcp6"
 		}
-		c, err := DialContext(ctx, network, ":0", addr)
+		c, err := DialContext(ctx, network, laddr, addr)
 		if err == nil {
 			client.chLaddr <- c.LocalAddr()
 		} else {


### PR DESCRIPTION
This resolves part of #1. As discussed in the issue, devices like laptops might move among network environments with different firewall settings. It would be useful to be able to bind to a fixed port and / or a random port.

To support this feature, ~~the rendezvous service needs to gather information from multiple connections before doing the exchange, so~~ the message spec needs to be changed. The current way of message serialization is not extensible, so this PR introduces a version 2 scheme designed with forward compatibility in mind.

*Although all future development will be based on version 2 scheme, there is no current plan to deprecate version 1 endpoint support for the rendezvous service.*

**Implementation note:**
Current implementation tries all port combinations sequentially until one succeeds. e.g. if each side opens 2 ports, then there will be 2x2=4 potential attempts:
```
side A port 1 -- side B port 1
side A port 1 -- side B port 2
side A port 2 -- side B port 1
side A port 2 -- side B port 2
```
An earlier implementation suggested testing all port combinations simultaneously after exchanging all port information. This idea was rejected since the two sides might end up choosing two different connections, and also it involves major changes in the rendezvous protocol.