### PR TITLE
Tailscale integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Highlights (aka "Why making another file-transfer tool?"):
 
 - Designed for personal use; no need to copy-paste a token / code for each transfer
-- Rendezvous service runs distributively on [serverless edge function](https://deno.com/deploy/docs),
+- Rendezvous service runs distributively on [serverless edge function](https://stackoverflow.blog/2023/02/23/how-edge-functions-move-your-back-end-close-to-your-front-end/),
   a robust solution with low latency worldwide. ([How does this work?](docs/mechanism.md))
 
 Other features:
@@ -15,6 +15,7 @@ Other features:
 - Compression (gzip)
 - Cross platform: Linux, macOS, Windows
 - Support transfering multiple files and directories
+- Optional [Tailscale integration](docs/advanced.md#tailscale-integration)
 
 See also [comparison table with similar tools](#similar-projects).
 
@@ -57,7 +58,7 @@ You can run the sender and receiver in arbitrary order.
 Whenever both sides are up and running, they will attempt to establish a P2P connection.
 If you see messages such as `rendezvous timeout`, at least one side is behind a firewall or a strict NAT that prohibits P2P connection.
 
-For advanced configuration and self-hosting (it's free & takes only 5 minutes!), check out [the docs here](docs/advanced.md).
+For advanced configuration and self-hosting, check out [the docs here](docs/advanced.md).
 
 
 ## Similar projects
@@ -68,7 +69,7 @@ For advanced configuration and self-hosting (it's free & takes only 5 minutes!),
 | LAN                                                          | O                                       | O    | O       | O                                        | O                                       |
 | WAN (local ↔︎ remote)                                         | O                                       | O    | O       | P                                        | O                                       |
 | WAN (remote ↔︎ remote)                                        |                                         | P    | O       | P                                        | O                                       |
-| relay                                                        |                                         |      |         | P                                        | O                                       |
+| relay                                                        |                                         |      | P       | P                                        | O                                       |
 | p2p                                                          |                                         |      | O       | O                                        | O                                       |
 | distributive                                                 |                                         |      | O       | O                                        |                                         |
 
@@ -86,3 +87,8 @@ Apart from the dependencies listed in [`go.mod`](go.mod), this project is also b
 - [**mholt/archiver**](https://github.com/mholt/archiver): tar/untar implementation
 - [**libp2p/go-reuseport**](https://github.com/libp2p/go-reuseport): address reuse for TCP hole-punching
 - [**egoist/bina**](https://github.com/egoist/bina): installation script
+- [**Tailscale**](https://tailscale.com), as one of the connection option, provides a painstaking implementation of NAT traversal and a distributive relay service
+
+## Disclaimer
+
+This project is not associated with Deno Land Inc. or Tailscale Inc.

--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/contextualist/acp/pkg/config"
 	"github.com/contextualist/acp/pkg/pnet"
 	"github.com/contextualist/acp/pkg/tui"
 )
@@ -62,13 +63,13 @@ func main() {
 		return
 	}
 	if *doSetup || *doSetupWith != "" {
-		checkErr(setup(*doSetupWith))
+		checkErr(config.Setup(*doSetupWith))
 		return
 	}
 
 	filenames := flag.Args()
-	conf := mustGetConfig()
-	conf.applyDefault()
+	conf := config.MustGetConfig()
+	conf.ApplyDefault()
 
 	ctx, userCancel := context.WithCancel(context.Background())
 	logger = tui.NewLoggerControl(*debug)
@@ -77,7 +78,7 @@ func main() {
 	tui.RunProgram(loggerModel, userCancel, *destination == "-")
 }
 
-func transfer(ctx context.Context, conf *Config, filenames []string, loggerModel tea.Model) {
+func transfer(ctx context.Context, conf *config.Config, filenames []string, loggerModel tea.Model) {
 	defer logger.End()
 
 	conn, err := pnet.HolePunching(

--- a/cmd/acp/strategy.go
+++ b/cmd/acp/strategy.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Merge strategy lists from two parties into a common one,
+// following the precedency set by the first party.
+func strategyConsensus(pa, pb []string) (c []string) {
+	pbSet := make(map[string]struct{}, len(pb))
+	for _, x := range pb {
+		pbSet[x] = struct{}{}
+	}
+
+	for _, x := range pa {
+		if _, ok := pbSet[x]; ok {
+			c = append(c, x)
+		}
+	}
+	logger.Debugf("strategy: a=%v, b=%v, consensus=%v", pa, pb, c)
+	return
+}
+
+// Map a func onto a slice, for each element returning a result or an error
+func tryEach[U, V any](a []U, fn func(U) (V, error)) (r []V, errs []error) {
+	for _, x := range a {
+		y, err := fn(x)
+		if err != nil {
+			logger.Debugf("attempt failed: %v", err)
+			errs = append(errs, err)
+			continue
+		}
+		r = append(r, y)
+	}
+	return
+}
+
+// Map a func onto a slice, until returning the first successful result
+func tryUntil[U, V any](a []U, fn func(U) (V, error)) (r V, err error) {
+	var errs []error
+	for _, x := range a {
+		r, err = fn(x)
+		if err != nil {
+			logger.Debugf("attempt failed: %v", err)
+			errs = append(errs, err)
+			continue
+		}
+		return
+	}
+	err = fmt.Errorf("all attempts failed: %w", errors.Join(errs...))
+	return
+}
+
+func must[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/cmd/acp/stream.go
+++ b/cmd/acp/stream.go
@@ -4,20 +4,12 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/klauspost/pgzip"
-	aead "github.com/shadowsocks/go-shadowsocks2/shadowaead"
 )
-
-func encrypted(conn net.Conn, psk []byte) (net.Conn, error) {
-	cipher, err := aead.Chacha20Poly1305(psk)
-	conn = aead.NewConn(conn, cipher)
-	return conn, err
-}
 
 func sendFiles(filenames []string, to io.WriteCloser) (err error) {
 	defer to.Close()

--- a/cmd/acp/update.go
+++ b/cmd/acp/update.go
@@ -50,6 +50,7 @@ func tryUpdate(exe string, repo string, currTag string) error {
 	if err != nil {
 		return fmt.Errorf("failed to update: %w", err)
 	}
+	fmt.Println("acp has been updated")
 	return nil
 }
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -15,6 +15,10 @@ List of configurable options:
 	- `[0]`: bind to a random port;
 	- `[9527]`: bind to port 9527;
 	- `[0,9527]`: bind to a random port and port 9527.
+- `strategy` (default: `["tcp_punch"]`): List of dialers for connection attempts, ordered by preference.
+  Available dialers:
+	- `tcp_punch`: TCP hole-punching
+	- `tailscale`: TCP over Tailnet / Taildrop (requires Tailscale running)
 - `upnp` (default: `false`): Request UPnP port mapping from supported router.
   This may not work for random port.
 
@@ -54,3 +58,10 @@ acp - < tmp-file
 # receiver
 acp -d - > tmp-file
 ```
+
+
+## Tailscale integration
+
+Tailscale has a more robust NAT traversal implementation and [distributed relay fallback](https://tailscale.com/blog/how-tailscale-works/#encrypted-tcp-relays-derp), so it is guarenteed to make connections in all cases. Acp can use Tailscale as a transport backend if you have Tailscale running on both side.
+
+If you have Tailscale running before installing acp, Tailscale support is automatically enabled for acp. Otherwise you can set `strategy: ["tailscale","tcp-punch"]` in config to enable Tailscale support after installing Tailscale.

--- a/docs/mechanism.md
+++ b/docs/mechanism.md
@@ -59,4 +59,5 @@ The following steps take place to create such mappings and use them for P2P conn
 </p>
 
 *Still curious about the implementation?*
-You can find the rendezvous service in [edge/index.ts](../edge/index.ts) and the client-size of hole-punching in [pkg/pnet/p2p.go](../pkg/pnet/p2p.go).
+You can find the rendezvous service in [edge/index.ts](../edge/index.ts) and the client-side of hole-punching in [pkg/pnet/p2p.go](../pkg/pnet/p2p.go).
+BTW, you would probably find it interesting to read [Tailscale's exteneded discussion on NAT traversal](https://tailscale.com/blog/how-nat-traversal-works/).

--- a/edge/index.ts
+++ b/edge/index.ts
@@ -3,6 +3,7 @@ type ConnInfo = Deno.ServeHandlerInfo
 interface ClientInfo {
   priAddr: string,
   chanName: string,
+  strategy?: string[],
   nPlan?: number,
   tsAddr?: string,
   tsCap?: number,
@@ -15,6 +16,7 @@ interface AddrPair {
 
 interface ReplyInfo {
   peerAddrs: AddrPair[],
+  strategy?: string[],
   peerNPlan?: number,
   tsAddr?: string,
   tsCap?: number,

--- a/edge/index.ts
+++ b/edge/index.ts
@@ -3,7 +3,9 @@ type ConnInfo = Deno.ServeHandlerInfo
 interface ClientInfo {
   priAddr: string,
   chanName: string,
-  nPlan: number,
+  nPlan?: number,
+  tsAddr?: string,
+  tsCap?: number,
 }
 
 interface AddrPair {
@@ -13,7 +15,9 @@ interface AddrPair {
 
 interface ReplyInfo {
   peerAddrs: AddrPair[],
-  peerNPlan: number,
+  peerNPlan?: number,
+  tsAddr?: string,
+  tsCap?: number,
 }
 
 
@@ -25,12 +29,13 @@ async function handleExchangeV2(req: Request, connInfo: ConnInfo): Promise<Respo
 
   const pubAddr = joinHostPort(connInfo.remoteAddr)
   const conn = req.body!.getReader({ mode: "byob" })
-  const { priAddr, chanName, nPlan = 1 }: ClientInfo = JSON.parse(
+  const { priAddr, chanName, nPlan = 1, ...otherInfo }: ClientInfo = JSON.parse(
     new TextDecoder().decode(await receivePacket(conn))
   )
   const reply: ReplyInfo = {
     peerAddrs: [{ pubAddr, priAddr }],
     peerNPlan: nPlan,
+    ...otherInfo,
   }
   const x0 = JSON.stringify(reply)
   //console.log(`accepted from ${x0}`)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/lipgloss v0.8.0 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/huin/goupnp v1.2.0 h1:uOKW26NG1hsSSbXIZ1IR7XP9Gjd1U8pnLaCMgntmkmY=
 github.com/huin/goupnp v1.2.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
@@ -55,6 +57,7 @@ golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"crypto/rand"
@@ -27,7 +27,7 @@ type Config struct {
 	UPnP    bool   `json:"upnp,omitempty"`
 }
 
-func (conf *Config) applyDefault() {
+func (conf *Config) ApplyDefault() {
 	if conf.Server == "" {
 		conf.Server = "https://acp.deno.dev"
 	}
@@ -38,7 +38,7 @@ func (conf *Config) applyDefault() {
 
 var configFilename = filepath.Join(userConfigDir(), "acp", "config.json")
 
-func setup(confStr string) (err error) {
+func Setup(confStr string) (err error) {
 	var conf *Config
 	if confStr != "" {
 		conf = &Config{}
@@ -64,7 +64,7 @@ func setup(confStr string) (err error) {
 		confBytes, _ := json.Marshal(&conf)
 		confStr = string(confBytes)
 	}
-	conf.applyDefault()
+	conf.ApplyDefault()
 	fmt.Printf(`acp is set up on this machine. To set up another machine, run the following command there
 (DO NOT share the command publicly as it contains encryption keys)
 	
@@ -79,7 +79,7 @@ If you already have the executable, run
 	return nil
 }
 
-func mustGetConfig() *Config {
+func MustGetConfig() *Config {
 	conf, err := getConfig()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,12 +19,13 @@ const (
 // Config defines the user-specific information for the transfer.
 // In general, it needs to be consistent across all devices of a user.
 type Config struct {
-	ID      string `json:"id"`
-	PSK     string `json:"psk"`
-	Server  string `json:"server,omitempty"`
-	UseIPv6 bool   `json:"ipv6,omitempty"`
-	Ports   []int  `json:"ports,omitempty"`
-	UPnP    bool   `json:"upnp,omitempty"`
+	ID       string   `json:"id"`
+	PSK      string   `json:"psk"`
+	Server   string   `json:"server,omitempty"`
+	UseIPv6  bool     `json:"ipv6,omitempty"`
+	Ports    []int    `json:"ports,omitempty"`
+	UPnP     bool     `json:"upnp,omitempty"`
+	Strategy []string `json:"strategy,omitempty"`
 }
 
 func (conf *Config) ApplyDefault() {
@@ -33,6 +34,9 @@ func (conf *Config) ApplyDefault() {
 	}
 	if len(conf.Ports) == 0 {
 		conf.Ports = []int{0}
+	}
+	if len(conf.Strategy) == 0 {
+		conf.Strategy = []string{"tcp_punch"}
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ func TestSetup(t *testing.T) {
 	if _, err := getConfig(); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Config exists before creation; err: %v", err)
 	}
-	if err := setup(""); err != nil {
+	if err := Setup(""); err != nil {
 		t.Fatalf("Config initialization failed: %v", err)
 	}
 	conf, err := getConfig()
@@ -35,7 +35,7 @@ func TestSetupWith(t *testing.T) {
 		Ports:   []int{0, 9527},
 	}
 	conf0Bytes, _ := json.Marshal(&conf0)
-	if err := setup(string(conf0Bytes)); err != nil {
+	if err := Setup(string(conf0Bytes)); err != nil {
 		t.Fatalf("Config override failed: %v", err)
 	}
 	conf, err := getConfig()
@@ -46,7 +46,7 @@ func TestSetupWith(t *testing.T) {
 		t.Fatalf("Config does not match the intented setup value: expect: %+v, got: %+v", conf0, conf)
 	}
 
-	if err := setup(`{"ipv6":"true"}`); err == nil {
+	if err := Setup(`{"ipv6":"true"}`); err == nil {
 		t.Fatalf("Setup failed to catch an invalid input")
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,11 +28,12 @@ func TestSetup(t *testing.T) {
 
 func TestSetupWith(t *testing.T) {
 	conf0 := Config{
-		ID:      "AAAAAAAA",
-		PSK:     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-		Server:  "http://localhost:8000",
-		UseIPv6: true,
-		Ports:   []int{0, 9527},
+		ID:       "AAAAAAAA",
+		PSK:      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		Server:   "http://localhost:8000",
+		UseIPv6:  true,
+		Ports:    []int{0, 9527},
+		Strategy: []string{"tcp_punch"},
 	}
 	conf0Bytes, _ := json.Marshal(&conf0)
 	if err := Setup(string(conf0Bytes)); err != nil {

--- a/pkg/pnet/p2p.go
+++ b/pkg/pnet/p2p.go
@@ -32,7 +32,9 @@ type (
 	SelfInfo struct {
 		PriAddr  string `json:"priAddr"`
 		ChanName string `json:"chanName"`
-		NPlan    int    `json:"nPlan"`
+		NPlan    int    `json:"nPlan,omitempty"`
+		TSAddr   string `json:"tsAddr,omitempty"`
+		TSCap    uint   `json:"tsCap,omitempty"`
 	}
 	AddrPair struct {
 		PriAddr string `json:"priAddr"`
@@ -41,7 +43,9 @@ type (
 	PeerInfo struct {
 		Laddr     string
 		PeerAddrs []AddrPair `json:"peerAddrs"`
-		PeerNPlan int        `json:"peerNPlan"`
+		PeerNPlan int        `json:"peerNPlan,omitempty"`
+		TSAddr    string     `json:"tsAddr,omitempty"`
+		TSCap     uint       `json:"tsCap,omitempty"`
 	}
 )
 

--- a/pkg/pnet/p2p.go
+++ b/pkg/pnet/p2p.go
@@ -30,11 +30,12 @@ type (
 	}
 
 	SelfInfo struct {
-		PriAddr  string `json:"priAddr"`
-		ChanName string `json:"chanName"`
-		NPlan    int    `json:"nPlan,omitempty"`
-		TSAddr   string `json:"tsAddr,omitempty"`
-		TSCap    uint   `json:"tsCap,omitempty"`
+		PriAddr  string   `json:"priAddr"`
+		ChanName string   `json:"chanName"`
+		Strategy []string `json:"strategy,omitempty"`
+		NPlan    int      `json:"nPlan,omitempty"`
+		TSAddr   string   `json:"tsAddr,omitempty"`
+		TSCap    uint     `json:"tsCap,omitempty"`
 	}
 	AddrPair struct {
 		PriAddr string `json:"priAddr"`
@@ -43,6 +44,7 @@ type (
 	PeerInfo struct {
 		Laddr     string
 		PeerAddrs []AddrPair `json:"peerAddrs"`
+		Strategy  []string   `json:"strategy,omitempty"`
 		PeerNPlan int        `json:"peerNPlan,omitempty"`
 		TSAddr    string     `json:"tsAddr,omitempty"`
 		TSCap     uint       `json:"tsCap,omitempty"`

--- a/pkg/pnet/portmapping.go
+++ b/pkg/pnet/portmapping.go
@@ -28,7 +28,7 @@ type routerClient interface {
 	GetExternalIPAddress() (string, error)
 }
 
-func addPortMapping(ctx context.Context, ports ...int) error {
+func AddPortMapping(ctx context.Context, ports ...int) error {
 	client, err := pickRouterClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to find a router client: %w", err)

--- a/pkg/stream/dialer.go
+++ b/pkg/stream/dialer.go
@@ -1,0 +1,57 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/contextualist/acp/pkg/config"
+	"github.com/contextualist/acp/pkg/pnet"
+)
+
+// A Dialer establishes a stream for sending / receiving files, with the help of a
+// rendezvous service.
+//
+// After implementing a new Dialer:
+// 1. Register
+//
+//	func init() {
+//		registerDialer("dialer_name", &DialerImpl{})
+//	}
+//
+// 2. Specify information exchange in pnet.SelfInfo and pnet.PeerInfo
+// 3. (optional) Provide configurable options in config.Config
+type Dialer interface {
+	// Initialize Dialer from config and environment, while checking availability.
+	// Return ErrNotAvailable if Dialer is not supported
+	Init(conf config.Config) error
+	// Populate the info struct to be sent to rendezvous service for information exchange
+	SetInfo(info *pnet.SelfInfo)
+	// Base on the info received, establish a stream as the sender
+	IntoSender(ctx context.Context, info pnet.PeerInfo) (io.WriteCloser, error)
+	// Base on the info received, establish a stream as the receiver
+	IntoReceiver(ctx context.Context, info pnet.PeerInfo) (io.ReadCloser, error)
+}
+
+var allDialers = make(map[string]Dialer)
+
+func registerDialer(name string, d Dialer) {
+	allDialers[name] = d
+}
+
+func GetDialer(name string) (Dialer, error) {
+	d, ok := allDialers[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown dialer %s", name)
+	}
+	return d, nil
+}
+
+var ErrNotAvailable = errors.New("this dialer is not available")
+
+var defaultLogger pnet.Logger
+
+func SetLogger(l pnet.Logger) {
+	defaultLogger = l
+}

--- a/pkg/stream/layer.go
+++ b/pkg/stream/layer.go
@@ -1,0 +1,13 @@
+package stream
+
+import (
+	"net"
+
+	aead "github.com/shadowsocks/go-shadowsocks2/shadowaead"
+)
+
+func encrypted(conn net.Conn, psk []byte) (net.Conn, error) {
+	cipher, err := aead.Chacha20Poly1305(psk)
+	conn = aead.NewConn(conn, cipher)
+	return conn, err
+}

--- a/pkg/stream/tailscale.go
+++ b/pkg/stream/tailscale.go
@@ -1,0 +1,253 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/contextualist/acp/pkg/config"
+	"github.com/contextualist/acp/pkg/pnet"
+	tsapi "github.com/contextualist/acp/pkg/tailscale"
+)
+
+func init() {
+	registerDialer("tailscale", &Tailscale{tun: &tailscaleTun{}, tdrop: &taildrop{}})
+}
+
+type TSCapability uint
+
+const (
+	TSTaildrop TSCapability = 1 << iota
+	TSTun
+)
+
+type Tailscale struct {
+	tun        *tailscaleTun
+	tdrop      *taildrop
+	capability TSCapability
+}
+
+func (d *Tailscale) Init(conf config.Config) error {
+	if d.tun.Init(conf) == nil {
+		d.capability |= TSTun
+	}
+	if d.tdrop.Init(conf) == nil {
+		d.capability |= TSTaildrop
+	}
+	if d.capability == 0 {
+		return ErrNotAvailable
+	}
+	return nil
+}
+
+func (d *Tailscale) SetInfo(info *pnet.SelfInfo) {
+	if d.capability&TSTun != 0 {
+		d.tun.SetInfo(info)
+	} else {
+		d.tdrop.SetInfo(info)
+	}
+	info.TSCap = uint(d.capability)
+}
+
+func (d *Tailscale) IntoSender(ctx context.Context, info pnet.PeerInfo) (io.WriteCloser, error) {
+	inner, err := d.pickImpl(d.capability, TSCapability(info.TSCap))
+	if err != nil {
+		return nil, err
+	}
+	return inner.IntoSender(ctx, info)
+}
+
+func (d *Tailscale) IntoReceiver(ctx context.Context, info pnet.PeerInfo) (io.ReadCloser, error) {
+	inner, err := d.pickImpl(TSCapability(info.TSCap), d.capability)
+	if err != nil {
+		return nil, err
+	}
+	return inner.IntoReceiver(ctx, info)
+}
+
+func (d *Tailscale) pickImpl(cap1, cap2 TSCapability) (Dialer, error) {
+	cap := cap1 & cap2
+	if cap&TSTun != 0 {
+		defaultLogger.Debugf("using Tailscale Tun")
+		return d.tun, nil
+	}
+	if cap&TSTaildrop != 0 {
+		defaultLogger.Debugf("using Taildrop")
+		return d.tdrop, nil
+	}
+	return nil, errors.New("neither of Tailscale Tun and Taildrop is supported on both side")
+}
+
+type tailscaleTun struct {
+	laddr string
+}
+
+func (d *tailscaleTun) Init(conf config.Config) error {
+	addrs, _, err := tsapi.Interface()
+	if err != nil || len(addrs) == 0 {
+		defaultLogger.Debugf("tailscale network interface search failed, found addrs %v: %v", addrs, err)
+		return ErrNotAvailable
+	}
+	laddr := fmt.Sprintf("%s:%v", addrs[0].String(), conf.Ports[0])
+	listener, err := pnet.Listen(context.TODO(), "tcp", laddr)
+	if err != nil {
+		defaultLogger.Debugf("listen at tailscale addr %s failed: %v", laddr, err)
+		return ErrNotAvailable
+	}
+	d.laddr = listener.Addr().String()
+	_ = listener.Close()
+	defaultLogger.Debugf("tailscale IP address is available")
+	return nil
+}
+
+func (d *tailscaleTun) SetInfo(info *pnet.SelfInfo) {
+	info.TSAddr = d.laddr
+}
+
+func (d *tailscaleTun) IntoSender(ctx context.Context, info pnet.PeerInfo) (io.WriteCloser, error) {
+	return pnet.RendezvousWithTimeout(ctx, d.laddr, []pnet.AddrPair{{PriAddr: info.TSAddr, PubAddr: info.TSAddr}})
+}
+
+func (d *tailscaleTun) IntoReceiver(ctx context.Context, info pnet.PeerInfo) (io.ReadCloser, error) {
+	return pnet.RendezvousWithTimeout(ctx, d.laddr, []pnet.AddrPair{{PriAddr: info.TSAddr, PubAddr: info.TSAddr}})
+}
+
+type taildrop struct {
+	cli  *tsapi.TSCli
+	tsIP string
+}
+
+func (d *taildrop) Init(_ config.Config) error {
+	bin, err := tsapi.Path()
+	if err != nil {
+		defaultLogger.Debugf("not found: %v", err)
+		return ErrNotAvailable
+	}
+	d.cli = &tsapi.TSCli{Prefix: []string{bin}}
+
+	if soc, ok := os.LookupEnv("TS_SOCKET"); ok {
+		defaultLogger.Debugf("will be using socket %s when running tailscale", soc)
+		d.cli.Prefix = append(d.cli.Prefix, fmt.Sprintf("--socket=%s", soc))
+	}
+
+	sf, err := d.cli.RunStatus(context.TODO())
+	if err != nil {
+		defaultLogger.Debugf(err.Error())
+		return ErrNotAvailable
+	}
+	d.tsIP = sf.TsIPs[0]
+	if runtime.GOOS == "linux" && sf.Tun {
+		// heuristic test if tailscaled is running as root
+		defaultLogger.Debugf("will be running tailscale as root")
+		d.cli.Prefix = append([]string{"sudo"}, d.cli.Prefix...)
+	}
+
+	defaultLogger.Debugf("taildrop is available")
+	return nil
+}
+
+func (d *taildrop) SetInfo(info *pnet.SelfInfo) {
+	info.TSAddr = d.tsIP
+}
+
+const TmpArcName = "acp-tmp.tar.gz"
+
+func (d *taildrop) IntoSender(ctx context.Context, info pnet.PeerInfo) (io.WriteCloser, error) {
+	peerIP := stripPort(info.TSAddr)
+	return d.cli.StartCp(ctx, TmpArcName, peerIP, defaultLogger.Infof)
+}
+
+func (d *taildrop) IntoReceiver(ctx context.Context, info pnet.PeerInfo) (r io.ReadCloser, err error) {
+	var tsInbox string
+	switch runtime.GOOS {
+	case "linux":
+		tsInbox, err = os.Getwd()
+	case "darwin", "windows":
+		var home string
+		home, err = os.UserHomeDir()
+		tsInbox = filepath.Join(home, "Downloads")
+	default:
+		return nil, fmt.Errorf("OS %s is not supported", runtime.GOOS)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error getting Taildrop receive dir: %w", err)
+	}
+	targetName := filepath.Join(tsInbox, TmpArcName)
+
+	defaultLogger.Infof("Taildrop receiving...")
+	if runtime.GOOS == "linux" {
+		out, err := d.cli.RunGet(ctx, ".")
+		if err != nil {
+			return nil, fmt.Errorf("error running tailscale file get: %w\noutput:\n%s", err, string(out))
+		}
+	} else {
+		// The tailscale daemon automatically receives the file to Downloads, so we wait for it to finish
+		// CAVEAT: if `targetName` already exist, tailscale daemon will receive file as `targetName 1`
+		err := waitFileTransferEnd(targetName)
+		if err != nil {
+			return nil, fmt.Errorf("error waiting for Taildrop receive: %w", err)
+		}
+	}
+	fi, err := os.Open(targetName)
+	if err != nil {
+		return nil, err
+	}
+	return &fileWithCleanup{fi}, nil
+}
+
+func stripPort(s string) string {
+	ap, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return s
+	}
+	return ap.Addr().String()
+}
+
+func waitFileTransferEnd(fname string) (err error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("cannot create file watcher: %w", err)
+	}
+	defer watcher.Close()
+	parent := path.Dir(fname)
+	err = watcher.Add(parent)
+	if err != nil {
+		return fmt.Errorf("cannot subscribe watcher to path %s: %w", parent, err)
+	}
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if !strings.HasPrefix(event.Name, fname) {
+				continue
+			}
+			defaultLogger.Debugf("fs event: %v", event)
+			if event.Has(fsnotify.Create) && event.Name == fname {
+				return
+			}
+		case err = <-watcher.Errors:
+			return
+		}
+	}
+}
+
+type fileWithCleanup struct {
+	*os.File
+}
+
+func (f *fileWithCleanup) Close() error {
+	_ = os.Remove(f.File.Name())
+	return f.File.Close()
+}

--- a/pkg/stream/tcppunch.go
+++ b/pkg/stream/tcppunch.go
@@ -1,0 +1,102 @@
+package stream
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/contextualist/acp/pkg/config"
+	"github.com/contextualist/acp/pkg/pnet"
+)
+
+func init() {
+	registerDialer("tcp_punch", &TcpHolePunch{})
+}
+
+type TcpHolePunch struct {
+	bridgeURL string
+	id        string
+	psk       []byte
+	// Whether to use IPv6 instead of IPv4 for rendezvous
+	useIPv6 bool
+	// Local port(s) to be used for rendezvous
+	ports []int
+	// Whether to try requesting uPnP port mapping from the router
+	uPnP bool
+}
+
+func (d *TcpHolePunch) Init(conf config.Config) (err error) {
+	d.bridgeURL = conf.Server + "/v2/exchange"
+	d.id = conf.ID
+	d.psk, err = base64.StdEncoding.DecodeString(conf.PSK)
+	if err != nil {
+		return fmt.Errorf("error decoding PSK: %w", err)
+	}
+	d.useIPv6 = conf.UseIPv6
+	d.ports = conf.Ports
+	d.uPnP = conf.UPnP
+	return nil
+}
+
+func (d *TcpHolePunch) SetInfo(info *pnet.SelfInfo) {
+	info.NPlan = len(d.ports)
+}
+
+func (d *TcpHolePunch) IntoSender(ctx context.Context, info pnet.PeerInfo) (io.WriteCloser, error) {
+	conn, err := d.holePunching(ctx, info, true)
+	if err != nil {
+		return nil, err
+	}
+	return encrypted(conn, d.psk)
+}
+
+func (d *TcpHolePunch) IntoReceiver(ctx context.Context, info pnet.PeerInfo) (io.ReadCloser, error) {
+	conn, err := d.holePunching(ctx, info, false)
+	if err != nil {
+		return nil, err
+	}
+	return encrypted(conn, d.psk)
+}
+
+// HolePunching negotiates via a rendezvous server with a peer with the same id to establish a connection.
+func (d *TcpHolePunch) holePunching(ctx context.Context, info pnet.PeerInfo, isA bool) (conn net.Conn, err error) {
+	if d.uPnP {
+		err = pnet.AddPortMapping(ctx, d.ports...)
+		if err != nil {
+			defaultLogger.Infof("failed to add port mapping: %v", err)
+		}
+	}
+
+	nplan := len(d.ports)
+	if conn, err = pnet.RendezvousWithTimeout(ctx, info.Laddr, info.PeerAddrs); err == nil {
+		return conn, nil
+	}
+
+	// Try out the rest of nA x nB plans
+	var planp []int
+	for i := 0; i < tern(isA, nplan, info.PeerNPlan); i++ {
+		for j := 0; j < tern(isA, info.PeerNPlan, nplan); j++ {
+			planp = append(planp, d.ports[tern(isA, i, j)])
+		}
+	}
+	for q := range planp[1:] {
+		info, err := pnet.ExchangeConnInfo(ctx, d.bridgeURL, &pnet.SelfInfo{ChanName: d.id, NPlan: nplan}, q, d.useIPv6)
+		if err != nil {
+			return nil, err
+		}
+		if conn, err = pnet.RendezvousWithTimeout(ctx, info.Laddr, info.PeerAddrs); err == nil {
+			return conn, nil
+		}
+	}
+	return nil, errors.New("all rendezvous attempts failed")
+}
+
+func tern[T any](t bool, a T, b T) T {
+	if t {
+		return a
+	}
+	return b
+}

--- a/pkg/tailscale/cli.go
+++ b/pkg/tailscale/cli.go
@@ -1,0 +1,105 @@
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+)
+
+// Path searches and returns the Tailscale CLI executable location
+func Path() (bin string, err error) {
+	// https://tailscale.com/kb/1080/cli/#using-the-cli
+	bin, err = exec.LookPath("tailscale")
+	if err != nil {
+		if runtime.GOOS != "darwin" {
+			return
+		}
+		if bin, err = exec.LookPath("/Applications/Tailscale.app/Contents/MacOS/Tailscale"); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Wrapper of the tailscale command, exposing only a minimal interface
+// Set up the command Prefix before using (e.g. {"/path/to/tailscale", "-kwarg=value"})
+type TSCli struct {
+	Prefix []string
+}
+
+func (ts *TSCli) run(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, ts.Prefix[0], append(append([]string{}, ts.Prefix[1:]...), args...)...)
+}
+
+type TSStatus struct {
+	Tun   bool     `json:"TUN"`
+	TsIPs []string `json:"TailscaleIPs"`
+}
+
+func (ts *TSCli) RunStatus(ctx context.Context) (*TSStatus, error) {
+	out, err := ts.run(ctx, "status", "--json", "--peers=false").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query tailscale status: %w", err)
+	}
+	var r TSStatus
+	err = json.Unmarshal(out, &r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tailscale status: %w", err)
+	}
+	return &r, nil
+}
+
+func (ts *TSCli) StartCp(ctx context.Context, name string, target string, logE func(string, ...any)) (stdin io.WriteCloser, err error) {
+	cmd := ts.run(ctx, "file", "cp", "-name="+name, "-", target+":")
+	cmd.Stdout = nil
+	stdin, err = cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("error setting up tailscale process's stdin pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("error setting up tailscale process's stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("error starting tailscale file cp: %w", err)
+	}
+	// make sure that the returned WriteCloser's Close blocks until the subprocess finishes
+	stdinb := newWriteBlockingCloser(stdin)
+	go func() {
+		if errmsg, _ := io.ReadAll(stderr); len(errmsg) > 0 {
+			logE("from tailscale file cp: %s", string(errmsg))
+		}
+		if err := cmd.Wait(); err != nil {
+			logE("error running tailscale file cp: %v", err)
+		}
+		stdinb.NotifyExit()
+	}()
+	return stdinb, nil
+}
+
+func (ts *TSCli) RunGet(ctx context.Context, targetDir string) ([]byte, error) {
+	return ts.run(ctx, "file", "get", "-conflict=overwrite", targetDir).CombinedOutput()
+}
+
+type writeBlockingCloser struct {
+	io.WriteCloser
+	chExit chan struct{}
+}
+
+func newWriteBlockingCloser(inner io.WriteCloser) *writeBlockingCloser {
+	chExit := make(chan struct{})
+	return &writeBlockingCloser{inner, chExit}
+}
+
+func (w *writeBlockingCloser) NotifyExit() {
+	close(w.chExit)
+}
+
+func (w *writeBlockingCloser) Close() error {
+	err := w.WriteCloser.Close()
+	<-w.chExit
+	return err
+}

--- a/pkg/tailscale/interfaces.go
+++ b/pkg/tailscale/interfaces.go
@@ -1,0 +1,52 @@
+package tailscale
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// Adapted from tailscale.com/net/interfaces interfaces.go
+//
+// Interface returns the current machine's Tailscale interface, if any.
+// If none is found, all zero values are returned.
+// A non-nil error is only returned on a problem listing the system interfaces.
+func Interface() ([]netip.Addr, *net.Interface, error) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, iface := range ifs {
+		if !maybeTailscaleInterfaceName(iface.Name) {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		var tsIPs []netip.Addr
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok {
+				nip, ok := netip.AddrFromSlice(ipnet.IP)
+				nip = nip.Unmap()
+				if ok && IsTailscaleIP(nip) {
+					tsIPs = append(tsIPs, nip)
+				}
+			}
+		}
+		if len(tsIPs) > 0 {
+			return tsIPs, &iface, nil
+		}
+	}
+	return nil, nil, nil
+}
+
+// maybeTailscaleInterfaceName reports whether s is an interface
+// name that might be used by Tailscale.
+func maybeTailscaleInterfaceName(s string) bool {
+	return s == "Tailscale" ||
+		strings.HasPrefix(s, "wg") ||
+		strings.HasPrefix(s, "ts") ||
+		strings.HasPrefix(s, "tailscale") ||
+		strings.HasPrefix(s, "utun")
+}

--- a/pkg/tailscale/tsaddr.go
+++ b/pkg/tailscale/tsaddr.go
@@ -1,0 +1,42 @@
+package tailscale
+
+import (
+	"net/netip"
+	"sync"
+)
+
+// Adapted from tailscale.com/net/tsaddr tsaddr.go
+//
+// IsTailscaleIP reports whether ip is an IP address in a range that
+// Tailscale assigns from.
+func IsTailscaleIP(ip netip.Addr) bool {
+	if ip.Is4() {
+		return CGNATRange().Contains(ip) && !ChromeOSVMRange().Contains(ip)
+	}
+	return TailscaleULARange().Contains(ip)
+}
+
+var (
+	// CGNATRange returns the Carrier Grade NAT address range that
+	// is the superset range that Tailscale assigns out of.
+	// See https://tailscale.com/s/cgnat
+	// Note that Tailscale does not assign out of the ChromeOSVMRange.
+	CGNATRange = mustPrefix("100.64.0.0/10")
+	// ChromeOSVMRange returns the subset of the CGNAT IPv4 range used by
+	// ChromeOS to interconnect the host OS to containers and VMs. We
+	// avoid allocating Tailscale IPs from it, to avoid conflicts.
+	ChromeOSVMRange = mustPrefix("100.115.92.0/23")
+	// TailscaleULARange returns the IPv6 Unique Local Address range that
+	// is the superset range that Tailscale assigns out of.
+	TailscaleULARange = mustPrefix("fd7a:115c:a1e0::/48")
+)
+
+func mustPrefix(prefix string) func() *netip.Prefix {
+	return sync.OnceValue(func() *netip.Prefix {
+		v, err := netip.ParsePrefix(prefix)
+		if err != nil {
+			panic(err)
+		}
+		return &v
+	})
+}

--- a/pkg/tui/status.go
+++ b/pkg/tui/status.go
@@ -13,43 +13,53 @@ import (
 
 type (
 	// A StatusControl is the user handler for a StausModel
-	StatusControl struct {
-		*meteredReadWriteCloser
+	StatusControl[T io.Closer] struct {
+		*meteredReadWriteCloser[T]
 		chNext chan tea.Msg
 	}
 )
 
-func NewStatusControl() *StatusControl {
-	return &StatusControl{
+func NewStatusControl[T io.Closer]() *StatusControl[T] {
+	return &StatusControl[T]{
 		chNext: make(chan tea.Msg),
 	}
 }
 
 // Monitor wraps around a read/write stream for obtaining data transfer stats
-func (c *StatusControl) Monitor(stream io.ReadWriteCloser) io.ReadWriteCloser {
+func (c *StatusControl[T]) Monitor(stream T) T {
 	c.meteredReadWriteCloser = newMeteredReadWriteCloser(stream, 300*time.Millisecond)
-	return c.meteredReadWriteCloser
+	return any(c.meteredReadWriteCloser).(T)
 }
 
 // Next switches to the next BubbleTea Model and shut down current StatusModel
-func (c *StatusControl) Next(m tea.Model) {
+func (c *StatusControl[_]) Next(m tea.Model) {
 	c.chNext <- modelSwitchMsg{m}
 	close(c.chNext)
 }
 
-type meteredReadWriteCloser struct {
-	io.ReadWriteCloser
+type meteredReadWriteCloser[T io.Closer] struct {
+	reader      io.ReadCloser
+	writer      io.WriteCloser
 	rate, total atomic.Uint64
 	startTime   time.Time
 	ticker      *time.Ticker
 }
 
-func newMeteredReadWriteCloser(inner io.ReadWriteCloser, interval time.Duration) *meteredReadWriteCloser {
+// NOTE: inner should be io.ReadCloser | io.WriteCloser | io.ReadWriteCloser
+func newMeteredReadWriteCloser[T io.Closer](inner T, interval time.Duration) *meteredReadWriteCloser[T] {
 	ticker := time.NewTicker(interval)
-	m := &meteredReadWriteCloser{
-		ReadWriteCloser: inner,
-		startTime:       time.Now(),
-		ticker:          ticker,
+	m := &meteredReadWriteCloser[T]{
+		startTime: time.Now(),
+		ticker:    ticker,
+	}
+	if r, ok := any(inner).(io.ReadCloser); ok {
+		m.reader = r
+	}
+	if w, ok := any(inner).(io.WriteCloser); ok {
+		m.writer = w
+	}
+	if m.reader == nil && m.writer == nil {
+		panic("inner is neither io.ReadCloser nor io.WriteCloser")
 	}
 	go func() {
 		for range ticker.C {
@@ -59,43 +69,46 @@ func newMeteredReadWriteCloser(inner io.ReadWriteCloser, interval time.Duration)
 	return m
 }
 
-func (m *meteredReadWriteCloser) Read(p []byte) (n int, err error) {
-	n, err = m.ReadWriteCloser.Read(p)
+func (m *meteredReadWriteCloser[_]) Read(p []byte) (n int, err error) {
+	n, err = m.reader.Read(p)
 	m.total.Add(uint64(n))
 	return
 }
-func (m *meteredReadWriteCloser) Write(p []byte) (n int, err error) {
-	n, err = m.ReadWriteCloser.Write(p)
+func (m *meteredReadWriteCloser[_]) Write(p []byte) (n int, err error) {
+	n, err = m.writer.Write(p)
 	m.total.Add(uint64(n))
 	return
 }
-func (m *meteredReadWriteCloser) Close() error {
+func (m *meteredReadWriteCloser[_]) Close() error {
 	m.ticker.Stop()
-	return m.ReadWriteCloser.Close()
+	if m.reader != nil {
+		return m.reader.Close()
+	}
+	return m.writer.Close()
 }
 
 // A StatusModel displays a updating stats of data transfer
-type StatusModel struct {
+type StatusModel[T io.Closer] struct {
 	spinner spinner.Model
-	status  *StatusControl
+	status  *StatusControl[T]
 }
 
-func NewStatusModel(c *StatusControl) tea.Model {
-	return StatusModel{
+func NewStatusModel[T io.Closer](c *StatusControl[T]) tea.Model {
+	return StatusModel[T]{
 		spinner: spinner.New(spinner.WithSpinner(spinner.Points)),
 		status:  c,
 	}
 }
 
-func (m StatusModel) waitForNext() tea.Msg {
+func (m StatusModel[_]) waitForNext() tea.Msg {
 	return <-m.status.chNext
 }
 
-func (m StatusModel) Init() tea.Cmd {
+func (m StatusModel[_]) Init() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, m.waitForNext)
 }
 
-func (m StatusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m StatusModel[_]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -113,7 +126,7 @@ func (m StatusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m StatusModel) View() string {
+func (m StatusModel[_]) View() string {
 	rate, total := m.status.rate.Load(), m.status.total.Load()
 	return fmt.Sprintf("%s  %6s/s  %6s", m.spinner.View(), humanize.Bytes(rate), humanize.Bytes(total))
 }


### PR DESCRIPTION
Tailscale has a superior implementation of NAT traversal, and they have a distributive network of fallback relay. If user has access to communication channels established by Tailscale, we can take advantage of that.

Tailscale does have a similar service called Taildrop. However, having a narrower feature scope and being independent of Tailscale allow acp to deliver a simpler interface.

There are two ways to pass files within a Tailnet:
1. Direct TCP connections via Tailscale network interface
2. Taildrop

Both sides of transfer can negotiate and see if method 1 is feasible, or else fallback to method 2 (e.g. one side is running in userspace networking mode).
