### PR TITLE
Logging file access error instead of aborting transfer

### DIFF
--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -112,7 +112,10 @@ func transfer(ctx context.Context, conf *config.Config, filenames []string, logg
 		return
 	}
 
-	var status interface{ Next(tea.Model) }
+	var status interface {
+		Next(tea.Model) string
+		Logf(string, ...any)
+	}
 	if len(filenames) > 0 {
 		var s io.WriteCloser
 		strategyFinal := strategyConsensus(strategy, info.Strategy)
@@ -122,7 +125,7 @@ func transfer(ctx context.Context, conf *config.Config, filenames []string, logg
 		}
 		s, status = monitor(s)
 		logger.Debugf("sending...")
-		err = sendFiles(filenames, s)
+		err = sendFiles(filenames, s, status.Logf)
 	} else {
 		var s io.ReadCloser
 		strategyFinal := strategyConsensus(info.Strategy, strategy)
@@ -136,7 +139,7 @@ func transfer(ctx context.Context, conf *config.Config, filenames []string, logg
 	}
 
 	if !*debug {
-		status.Next(loggerModel)
+		exitStatement = status.Next(loggerModel) // save in-transit log, if any
 	}
 	checkErr(err)
 }

--- a/cmd/acp/stream.go
+++ b/cmd/acp/stream.go
@@ -11,7 +11,7 @@ import (
 	"github.com/klauspost/pgzip"
 )
 
-func sendFiles(filenames []string, to io.WriteCloser) (err error) {
+func sendFiles(filenames []string, to io.WriteCloser, errorf func(string, ...any)) (err error) {
 	defer to.Close()
 	z := pgzip.NewWriter(to)
 	defer z.Close()
@@ -29,7 +29,7 @@ func sendFiles(filenames []string, to io.WriteCloser) (err error) {
 		if err != nil {
 			return err
 		}
-		err = tarWalk(fname, tz)
+		err = tarWalk(fname, tz, errorf)
 		if err != nil {
 			return fmt.Errorf("tar: %w", err)
 		}

--- a/pkg/tui/auxlogger.go
+++ b/pkg/tui/auxlogger.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type (
+	auxLoggerControl struct {
+		ch         chan tea.Msg
+		chFinalLog chan string
+		maxRows    int
+	}
+	auxLoggerQuitMsg struct{}
+)
+
+func newAuxLoggerControl(maxRows int) auxLoggerControl {
+	return auxLoggerControl{make(chan tea.Msg), make(chan string), maxRows}
+}
+
+// Logf logs a message
+func (c auxLoggerControl) Logf(format string, a ...any) {
+	c.ch <- logMsg(fmt.Sprintf(format, a...))
+}
+
+// epilogue shuts down the logger and returns the current displayed log
+func (c auxLoggerControl) epilogue() string {
+	c.ch <- auxLoggerQuitMsg{}
+	close(c.ch)
+	return <-c.chFinalLog
+}
+
+// auxLoggerModel is a model that displays a rolling log alongside other models.
+// i.e. it is intended to be used as an embedded model
+type auxLoggerModel struct {
+	logger  auxLoggerControl
+	logs    []string
+	logRepr string
+}
+
+func newAuxLoggerModel(c auxLoggerControl) tea.Model {
+	return auxLoggerModel{logger: c}
+}
+
+func (m auxLoggerModel) waitForLog() tea.Msg {
+	return <-m.logger.ch
+}
+
+func (m auxLoggerModel) Init() tea.Cmd {
+	return m.waitForLog
+}
+
+func (m auxLoggerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case logMsg:
+		m.logs = append(m.logs, string(msg))
+		if len(m.logs) > m.logger.maxRows {
+			m.logs = m.logs[1:]
+		}
+		m.logRepr = strings.Join(m.logs, "\n")
+		return m, m.waitForLog
+	case auxLoggerQuitMsg:
+		final := m.logRepr
+		if final != "" {
+			heading := "Skipped errors:"
+			if len(m.logs) == m.logger.maxRows {
+				heading += fmt.Sprintf(" (showing only last %d entries)", m.logger.maxRows)
+			}
+			final = heading + "\n" + final
+		}
+		m.logger.chFinalLog <- final
+		close(m.logger.chFinalLog)
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m auxLoggerModel) View() string {
+	return m.logRepr
+}


### PR DESCRIPTION
This resolves #13.

It is often more desirable to skip and continue transferring on single-file failures, while the previous behavior of `acp` is to treat those as fatal error and interrupt the transfer.

This PR implements displaying the in-transfer file access errors in a rolling fashion. The 5 latest error messages will stay on the screen.